### PR TITLE
Add obsidian-limitless-lifelogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 ## Integrations
 
+- [obsidian-limitless-lifelogs](https://github.com/Maclean-D/obsidian-limitless-lifelogs) - Obsidian plugin to Sync your Limitless lifelog entries
 - [Obsidian-Limitless](https://github.com/skryl/obsidian-limitless) - Obsidian plugin to sync all of your Pendant transcripts to Obsidian.
 - [Raycast Extension](https://github.com/raycast/extensions/pull/17939) - Raycast extension for Limitless AI (pending approval).
 


### PR DESCRIPTION
## Description
Sync your Limitless AI lifelog entries directly into Obsidian markdown files.

## Why it should be included in the list
Actively under approval from Obsidian, also this was the first Limitless Obsidian plugin made.

## Your contribution type
- [X] Adding a new project